### PR TITLE
Add manual check before re-pulling kaggle dataset

### DIFF
--- a/dataset/data_loader.py
+++ b/dataset/data_loader.py
@@ -1,11 +1,15 @@
 import kaggle
+import os
 
 
 def load_kaggle():
-    dataset = 'paultimothymooney/chest-xray-pneumonia'
-    target = 'kaggle'
-    kaggle.api.authenticate()
-    kaggle.api.dataset_download_files(dataset=dataset, path=target, unzip=True, quiet=False)
+    if not os.path.exists(os.path.join('kaggle', 'chest_xray')):
+        dataset = 'paultimothymooney/chest-xray-pneumonia'
+        target = 'kaggle'
+        kaggle.api.authenticate()
+        kaggle.api.dataset_download_files(dataset=dataset, path=target, unzip=True, quiet=False)
+    else:
+        print('The Kaggle dataset is already downloaded')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This feature is now complete! The soultion is to print all the directories, and if the Kaggle dataset directory already is present, a new pull will not be performed.